### PR TITLE
Add missing media type

### DIFF
--- a/src/main/java/com/omertron/themoviedbapi/enumeration/Gender.java
+++ b/src/main/java/com/omertron/themoviedbapi/enumeration/Gender.java
@@ -20,8 +20,8 @@
 package com.omertron.themoviedbapi.enumeration;
 
 public enum Gender {
-    MALE(1),
-    FEMALE(2),
+    MALE(2),
+    FEMALE(1),
     UNKNOWN(0);
 
     private final int type;

--- a/src/main/java/com/omertron/themoviedbapi/enumeration/MediaType.java
+++ b/src/main/java/com/omertron/themoviedbapi/enumeration/MediaType.java
@@ -37,6 +37,10 @@ public enum MediaType {
      */
     TV,
     /**
+     * TV Season media type
+     */
+    SEASON,
+    /**
      * TV Episode media type
      */
     EPISODE;


### PR DESCRIPTION
The SEASON media type was missing, which caused errors during data retrieval.