### PR TITLE
Correct gender assignment

### DIFF
--- a/src/main/java/com/omertron/themoviedbapi/enumeration/Gender.java
+++ b/src/main/java/com/omertron/themoviedbapi/enumeration/Gender.java
@@ -20,8 +20,8 @@
 package com.omertron.themoviedbapi.enumeration;
 
 public enum Gender {
-    MALE(1),
-    FEMALE(2),
+    MALE(2),
+    FEMALE(1),
     UNKNOWN(0);
 
     private final int type;


### PR DESCRIPTION
Gender assignment were flipped, causing all women to be assigned MALE, and all men to be assigned FEMALE.